### PR TITLE
Update license to include new monospace font

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -13,6 +13,8 @@ This site also includes a number of images that have various copyright statuses,
 
 The Karla font files in `fec-cms/fec/fec/static/fonts/` are from [Google Web Fonts](https://fonts.google.com/specimen/Karla), licensed under the [SIL Open Font License](http://scripts.sil.org/cms/scripts/page.php?item_id=OFL), and copyright [Jonny Pinhorn](https://github.com/jonpinhorn) with Reserved Font Name ‘Karla'.
 
+The FEC currency monospace font files in `fec-cms/fec/fec/static/fonts/` are a custom, modified version of the Karla font by [Jonny Pinhorn](https://github.com/jonpinhorn), licensed under the [SIL Open Font License].
+
 The Gandhi Serif font files in `fec-cms/fec/fec/static/fonts/` are from [Librerias Gandhi](http://www.tipografiagandhi.com/), and copyright 2012 [Librerias Gandhi S.A. de C.V.](http://www.gandhi.com.mx/) with Reserved Font Name ‘Gandhi Serif’. The English version of this License is reproduced below.
 
 #### Full English version of the license text for Gandhi Serif:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -13,7 +13,7 @@ This site also includes a number of images that have various copyright statuses,
 
 The Karla font files in `fec-cms/fec/fec/static/fonts/` are from [Google Web Fonts](https://fonts.google.com/specimen/Karla), licensed under the [SIL Open Font License](http://scripts.sil.org/cms/scripts/page.php?item_id=OFL), and copyright [Jonny Pinhorn](https://github.com/jonpinhorn) with Reserved Font Name ‘Karla'.
 
-The FEC currency monospace font files in `fec-cms/fec/fec/static/fonts/` are a custom, modified version of the Karla font by [Jonny Pinhorn](https://github.com/jonpinhorn), licensed under the [SIL Open Font License].
+The FEC currency monospace font files in `fec-cms/fec/fec/static/fonts/` are a custom, modified version of the Karla font by [Jonny Pinhorn](https://github.com/jonpinhorn), licensed under the [SIL Open Font License](http://scripts.sil.org/cms/scripts/page.php?item_id=OFL).
 
 The Gandhi Serif font files in `fec-cms/fec/fec/static/fonts/` are from [Librerias Gandhi](http://www.tipografiagandhi.com/), and copyright 2012 [Librerias Gandhi S.A. de C.V.](http://www.gandhi.com.mx/) with Reserved Font Name ‘Gandhi Serif’. The English version of this License is reproduced below.
 


### PR DESCRIPTION
Proposed language for including the new monospace font, based on others' work.

The OFL permissions and conditions: (emphasis mine)
1) Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.

2) Original or **Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license.** These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.

3) **No Modified Version of the Font Software may use the Reserved Font Name(s)** unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.

4) **The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used** to promote, endorse or advertise any Modified Version, **except to acknowledge the contribution(s) of the Copyright Holder(s)** and the Author(s) or with their explicit written permission.

5) **The Font Software**, modified or unmodified, in part or in whole, **must be distributed entirely under this license**, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.